### PR TITLE
Removal of deprecated ssl directive

### DIFF
--- a/Wiki/nginx-proxy-setup.md
+++ b/Wiki/nginx-proxy-setup.md
@@ -20,11 +20,10 @@ vim default.conf
 ```text-plain
 # This part is for proxy and HTTPS configure
 server {
-    listen 443;
+    listen 443 ssl;
     server_name trilium.example.net; #change trilium.example.net to your domain without HTTPS or HTTP.
     ssl_certificate /etc/ssl/note/example.crt; #change /etc/ssl/note/example.crt to your path of crt file.
     ssl_certificate_key /etc/ssl/note/example.net.key; #change /etc/ssl/note/example.net.key to your path of key file.
-    ssl on;
     ssl_session_cache builtin:1000 shared:SSL:10m;
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
     ssl_ciphers HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;


### PR DESCRIPTION
The usage of ssl directive specified in https://triliumnext.github.io/Docs/Wiki/nginx-proxy-setup.html seems deprecated and was giving errors. The commit tries to address the issue
